### PR TITLE
Added Gradle binding for Newman insecure flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ postman {
     // when windows gives you lemons on cli output...
     // default: false
     disableUnicode = false
-    
+
+    // disables ssl verification checks and allows self-signed certificates
+    // default: off
+    insecure = true
+
     // creates junit compatible XML result files in directory
     // default: off
     xmlReportDir = 'build/testoutput'

--- a/src/main/java/uk/co/mruoc/postman/PostmanExtension.java
+++ b/src/main/java/uk/co/mruoc/postman/PostmanExtension.java
@@ -21,6 +21,7 @@ public class PostmanExtension implements NewmanSettings {
     private boolean stopOnError = false;
     private boolean noColor = true;
     private boolean disableUnicode = false;
+    private boolean insecure = false;
 
     @Override
     public FileTree getCollections() {
@@ -90,6 +91,15 @@ public class PostmanExtension implements NewmanSettings {
     @Override
     public boolean getDisableUnicode() {
         return disableUnicode;
+    }
+
+    @Override
+    public boolean getInsecure() {
+        return insecure;
+    }
+
+    public void setInsecure(boolean insecure) {
+        this.insecure = insecure;
     }
 
     public void setNoColor(boolean noColor) {

--- a/src/main/java/uk/co/mruoc/postman/newman/NewmanConfig.java
+++ b/src/main/java/uk/co/mruoc/postman/newman/NewmanConfig.java
@@ -44,6 +44,7 @@ class NewmanConfig {
             addBail();
             addNoColor();
             addDisableUnicode();
+            addInsecure();
         }
 
         private void addCollection() {
@@ -142,6 +143,10 @@ class NewmanConfig {
 
         private void addDisableUnicode() {
             params.add("disableUnicode", primitive(settings.getDisableUnicode()));
+        }
+
+        private void addInsecure() {
+            params.add("insecure", primitive(settings.getInsecure()));
         }
 
         private String endsWithJson(String fileName) {

--- a/src/main/java/uk/co/mruoc/postman/settings/NewmanSettings.java
+++ b/src/main/java/uk/co/mruoc/postman/settings/NewmanSettings.java
@@ -24,4 +24,6 @@ public interface NewmanSettings {
     boolean getNoColor();
 
     boolean getDisableUnicode();
+
+    boolean getInsecure();
 }

--- a/src/main/java/uk/co/mruoc/postman/settings/PreferredSettings.java
+++ b/src/main/java/uk/co/mruoc/postman/settings/PreferredSettings.java
@@ -17,6 +17,7 @@ public class PreferredSettings implements NewmanSettings {
     private Boolean stopOnError;
     private Boolean noColor;
     private Boolean disableUnicode;
+    private Boolean insecure;
 
     public PreferredSettings(Supplier<NewmanSettings> defaultSettings) {
         this.defaultSettings = defaultSettings;
@@ -102,6 +103,14 @@ public class PreferredSettings implements NewmanSettings {
         return disableUnicode;
     }
 
+    @Override
+    public boolean getInsecure() {
+        if (insecure == null) {
+            return getNewmanSettings().getInsecure();
+        }
+        return insecure;
+    }
+
     public void setCollections(FileTree collections) {
         this.collections = collections;
     }
@@ -140,6 +149,10 @@ public class PreferredSettings implements NewmanSettings {
 
     public void setJsonReportDir(String jsonReportDir) {
         this.jsonReportDir = jsonReportDir;
+    }
+
+    public void setInsecure(boolean insecure) {
+        this.insecure = insecure;
     }
 
     private NewmanSettings getNewmanSettings() {

--- a/src/main/java/uk/co/mruoc/postman/task/PostmanTask.java
+++ b/src/main/java/uk/co/mruoc/postman/task/PostmanTask.java
@@ -75,6 +75,10 @@ public class PostmanTask extends DefaultTask {
         settings.setDisableUnicode(disableUnicode);
     }
 
+    public void setInsecure(boolean insecure) {
+        settings.setInsecure(insecure);
+    }
+
     public void setHtmlReportDir(String htmlReportDir) {
         settings.setHtmlReportDir(htmlReportDir);
     }


### PR DESCRIPTION
Hey @michaelruocco, the config bindings are missing the setting to disable ssl cert checks, which I found useful in dealing with some test environments. This pull req is to help others with similar issues.
Cheers,
David